### PR TITLE
Improve Raspberry Pi setup utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,20 @@
-# raspberrypikuberdock
-Setting up a Raspberry Pi with Docker and Kubernetes
+# Raspberry Pi Kubernetes + Docker Setup
+
+This repository contains a small collection of scripts for configuring a
+headless Raspberry Pi with Docker and the lightweight Kubernetes
+distribution [k3s](https://k3s.io). It also includes a simple Python
+script for testing Bluetooth connectivity.
+
+## Usage
+
+After connecting to your Raspberry Pi over SSH, run the setup script:
+
+```bash
+./setup_raspberrypi.sh
+```
+
+This installs Docker and k3s. If k3s fails to start due to cgroup
+settings, follow the instructions printed at the end of the script.
+
+The `v1_bluetooth_test.py` file demonstrates scanning for and connecting
+to Bluetooth devices using the `pybluez` library.

--- a/setup_raspberrypi.sh
+++ b/setup_raspberrypi.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# Setup Docker and k3s on a Raspberry Pi
+# Usage: run this script after SSH-ing into the Pi
+
+set -euo pipefail
+
+sudo apt-get update && sudo apt-get upgrade -y
+sudo apt-get install -y apt-transport-https ca-certificates curl software-properties-common
+
+# Install Docker
+curl -fsSL https://get.docker.com -o get-docker.sh
+sudo sh get-docker.sh
+sudo systemctl enable docker
+sudo usermod -aG docker "$USER"
+
+# Install k3s (lightweight Kubernetes)
+curl -sfL https://get.k3s.io | sh -
+
+sudo kubectl get nodes
+
+cat <<'INSTRUCTIONS'
+If k3s fails to start with a cgroup v2 error, edit /boot/firmware/cmdline.txt
+and add the following parameters at the end of the line:
+
+cgroup_memory=1 cgroup_enable=memory systemd.unified_cgroup_hierarchy=1
+
+Reboot and then run:
+  sudo systemctl restart k3s
+  sudo systemctl status k3s
+INSTRUCTIONS

--- a/v1_bluetooth_test.py
+++ b/v1_bluetooth_test.py
@@ -1,4 +1,17 @@
-import bluetooth
+#!/usr/bin/env python3
+
+"""Simple Bluetooth connectivity test using PyBluez."""
+
+import sys
+
+try:
+    import bluetooth
+except ImportError:  # pragma: no cover - runtime dependency check
+    print(
+        "The 'bluetooth' module is required. Install it with 'pip install pybluez'.",
+        file=sys.stderr,
+    )
+    sys.exit(1)
 
 def scan_for_devices():
     print("Scanning for nearby Bluetooth devices...")
@@ -15,17 +28,20 @@ def scan_for_devices():
 
     return nearby_devices
 
-def connect_to_devices(device_address):
+def connect_to_device(device_address: str):
+    """Return an RFCOMM socket connected to ``device_address``."""
+
     print(f"Connecting to {device_address}...")
     sock = bluetooth.BluetoothSocket(bluetooth.RFCOMM)
     sock.connect((device_address, 1))
     return sock
 
 def send_and_receive(sock):
+    """Send a test message and print the response."""
+
     try:
         message = "Hello, Bluetooth device!"
         print(f"Sending message: {message}")
-        # Here you would typically send the message and wait for a response
         sock.send(message)
         response = sock.recv(1024)
         print(f"Received response: {response}")
@@ -37,5 +53,5 @@ if __name__ == "__main__":
 
     if devices:
         device_address = devices[0] # Use the first found device for testing
-        sock = connect_to_devices(device_address)
+        sock = connect_to_device(device_address)
         send_and_receive(sock)


### PR DESCRIPTION
## Summary
- flesh out the README with usage instructions
- add a `setup_raspberrypi.sh` script for installing Docker and k3s
- improve the Bluetooth test script with import checks and clearer naming

## Testing
- `python3 -m py_compile v1_bluetooth_test.py`

------
https://chatgpt.com/codex/tasks/task_e_685e2b2bf3ec8320b162254ae16a489c